### PR TITLE
fix: Readme 문서 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sudo apt install libnimf1 nimf nimf-anthy nimf-dev nimf-libhangul nimf-m17n nimf
 # Input method conflict
 # You can remove the ibus or disable ibus-daemon from booting
 # Sol1 : sudo apt purge ibus
-# Sol2 : sudo mv /usr/bin/ibus-daemon /usr/bin/ibus/ibus-daemon.bak
+# Sol2 : sudo mv /usr/bin/ibus-daemon /usr/bin/ibus-daemon.bak
 
 sudo rm -f /etc/apt/sources.list.d/hamonikr.list
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ sudo apt install nimf nimf-libhangul
 # nimf 입력기를 기본으로 설정합니다.
 im-config -n nimf
 
-# 만약 일본어, 중국어 등 다른언어를 사용하고 싶은 경우에는 다음과 같이 추가 패키지를 설치해줍니다.
+# 만약 일본어, 중국어 등 다른 언어를 사용하고 싶은 경우에는 다음과 같이 추가 패키지를 설치해줍니다.
 sudo apt install libnimf1 nimf nimf-anthy nimf-dev nimf-libhangul nimf-m17n nimf-rime
 ```
 
@@ -153,7 +153,7 @@ curl -sL https://pkg.hamonikr.org/add-hamonikr.apt | sudo -E bash -
 
 sudo apt install nimf nimf-libhangul
 
-# 만약 일본어, 중국어 등 다른언어를 사용하고 싶은 경우에는 다음과 같이 추가 패키지를 설치해줍니다.
+# 만약 일본어, 중국어 등 다른 언어를 사용하고 싶은 경우에는 다음과 같이 추가 패키지를 설치해줍니다.
 # Install additional packages as follows if you want to use other languages(Japanese, Chinese, etc.)
 sudo apt install libnimf1 nimf nimf-anthy nimf-dev nimf-libhangul nimf-m17n nimf-rime
 
@@ -171,7 +171,7 @@ curl -sL https://apt.hamonikr.org/setup_hamonikr.sun | sudo -E bash -
 ```
 sudo apt install nimf nimf-libhangul
 ```
-만약 일본어, 중국어 등 다른언어를 사용하고 싶은경우에는 다음과 같이 추가 패키지를 설치해줍니다.
+만약 일본어, 중국어 등 다른 언어를 사용하고 싶은경우에는 다음과 같이 추가 패키지를 설치해줍니다.
 ```
 sudo apt install libnimf1 nimf nimf-anthy nimf-dev nimf-libhangul nimf-m17n nimf-rime
 ```

--- a/README.md
+++ b/README.md
@@ -135,12 +135,17 @@ sudo apt install nimf nimf-libhangul
 # nimf 입력기를 기본으로 설정합니다.
 im-config -n nimf
 
-# If you want to use other languages(Japanese, Chinese, etc.)
+# 만약 일본어, 중국어 등 다른언어를 사용하고 싶은 경우에는 다음과 같이 추가 패키지를 설치해줍니다.
 sudo apt install libnimf1 nimf nimf-anthy nimf-dev nimf-libhangul nimf-m17n nimf-rime
 ```
 
 ## Ubuntu 20.04(>=) , Linux Mint 20
 ```
+# 우분투 21.10 이상을 기반으로 하는 배포판에서는 ibus-daemon이 자동으로 시작되어 입력기가 충돌됩니다.
+# 부팅시 ibus가 동작하지 않도록 ibus를 제거하거나 ibus-daemon을 비활성화할 수 있습니다.
+# 방법1 : sudo apt purge ibus
+# 방법2 : sudo mv /usr/bin/ibus-daemon /usr/bin/ibus-daemon.bak
+
 # nimf 패키지 저장소가 변경되었습니다. 예전에 사용하던 하모니카 APT 설정이 있는 경우 삭제합니다. 
 sudo rm -f /etc/apt/sources.list.d/hamonikr.list
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ im-config -n nimf
 ![nimf](docs/nimf.png)
 
 # nimf 설치
+## 하모니카 6.0
+```
+# nimf 패키지 저장소를 추가 또는 업그레이드를 합니다.
+wget -qO- https://update.hamonikr.org/add-update-repo.apt | sudo -E bash -
+
+# nimf 패키지를 설치합니다.
+sudo apt install nimf nimf-libhangul
+
+# nimf 입력기를 기본으로 설정합니다.
+im-config -n nimf
+
+# If you want to use other languages(Japanese, Chinese, etc.)
+sudo apt install libnimf1 nimf nimf-anthy nimf-dev nimf-libhangul nimf-m17n nimf-rime
+```
 
 ## Ubuntu 20.04(>=) , Linux Mint 20
 ```


### PR DESCRIPTION
Readme 문서 중 설치 관련해서 일부 항목을 수정하였습니다.
1. ibus-daemon을 비활성화하는 과정 중에 /usr/bin/ibus라는 디렉토리가 존재하지 않아 /usr/bin/ibus/ibus-daemon 대신 /usr/bin/ibus-daemon 으로 파일을 이동하는 것이 맞아 이를 수정했습니다.
2. 한국어 설치 방법에는 하모니카 6.0에 대한 설치 방법이 누락되어 있어 이를 추가하였습니다.
3. 한국어 설치 방법에서 Ubuntu 21.10 이상 배포판에 대한 ibus 충돌 문제를 해결하는 방법이 누락되어 이를 추가하였습니다.
4. 띄어쓰기를 수정하였습니다(다른언어 -> 다른 언어)