### PR TITLE
Fix copyright holder in im-nimf-qt6.cpp

### DIFF
--- a/modules/clients/qt6/im-nimf-qt6.cpp
+++ b/modules/clients/qt6/im-nimf-qt6.cpp
@@ -3,6 +3,7 @@
  * im-nimf-qt6.cpp
  * This file is part of Nimf.
  *
+ * Copyright (C) 2015-2019 Hodong Kim <hodong@nimfsoft.art>
  * Copyright (C) 2024 Kevin Kim <chaeya@gmail.com>
  *
  * Nimf is free software: you can redistribute it and/or modify it


### PR DESCRIPTION
안녕하세요.
이번에 새로 생성된 im-nimf-qt6.cpp 파일을 살펴보니,

```diff
--- ./im-nimf-qt5.cpp	2024-06-25 15:27:37.334973000 +0900
+++ ./im-nimf-qt6.cpp	2024-06-25 15:27:50.296099000 +0900
@@ -1,9 +1,9 @@
 /* -*- Mode: C++; indent-tabs-mode: nil; c-basic-offset: 2; tab-width: 2 -*- */
 /*
- * im-nimf-qt5.cpp
+ * im-nimf-qt6.cpp
  * This file is part of Nimf.
  *
- * Copyright (C) 2015-2019 Hodong Kim <cogniti@gmail.com>
+ * Copyright (C) 2024 Kevin Kim <chaeya@gmail.com>
  *
  * Nimf is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
@@ -423,7 +423,7 @@ NimfInputContext::NimfInputContext ()
 
 #ifndef USE_DLFCN
   m_im = nimf_im_new ();
-  m_settings = g_settings_new ("org.nimf.clients.qt5");
+  m_settings = g_settings_new ("org.nimf.clients.qt6");
   g_signal_connect (m_im, "preedit-start",
                     G_CALLBACK (NimfInputContext::on_preedit_start), this);
   g_signal_connect (m_im, "preedit-end",
@@ -456,18 +456,18 @@ NimfInputContext::NimfInputContext ()
   GSettingsSchema       *schema;
 
   source = gio_api->settings_schema_source_get_default ();
-  schema = gio_api->settings_schema_source_lookup (source, "org.nimf.clients.qt5", TRUE);
+  schema = gio_api->settings_schema_source_lookup (source, "org.nimf.clients.qt6", TRUE);
 
   if (schema == NULL)
   {
-    qWarning("org.nimf.clients.qt5 schema is not found.");
+    qWarning("org.nimf.clients.qt6 schema is not found.");
     return;
   }
 
   gio_api->settings_schema_unref (schema);
 
   m_im = nimf_api->im_new ();
-  m_settings = gio_api->settings_new ("org.nimf.clients.qt5");
+  m_settings = gio_api->settings_new ("org.nimf.clients.qt6");
   gobject_api->signal_connect_data (m_im, "preedit-start",
                                     G_CALLBACK (NimfInputContext::on_preedit_start), this, NULL, (GConnectFlags) 0);
   gobject_api->signal_connect_data (m_im, "preedit-end",
@@ -865,4 +865,4 @@ class NimfInputContextPlugin : public QPlatformInputCo
   }
 };
 
-#include "im-nimf-qt5.moc"
+#include "im-nimf-qt6.moc"
```

과거에 제가 작성했던 im-nimf-qt5.cpp 파일에서 qt5 부분을 qt6으로 변경하여 만든 파일인 것을 확인하였습니다.
저작권자에 제 이름이 누락되어서 저작권자를 추가합니다.