### PR TITLE
Replace hardcoded keyboard list with the list provided by libhangul

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,48 @@ sudo rpm -ivh ./nimf-1.3.8-2.opensuse_leap.kr.x86_64.rpm
 
 ``` 
 
+# 한글 자판 배열 추가
+
+libhangul에서 사용하는 한글 자판 배열은 두 경로에 XML 파일로 정의됩니다.
+
+* `/usr/share/libhangul/keyboards` 경로에 설치된 파일은 모든 사용자에게서 인식됩니다.
+* `$HOME/.local/share/libhangul/keyboards` 또는 `$XDG_DATA_HOME/libhangul/keyboards` 경로에 설치된 파일은 개별 사용자에게 인식됩니다.
+
+자판 배열 파일 구조는 기본으로 설치되는 [두벌식 배열 파일](docs/hangul-keyboard-2.xml)과 [자모 기본조합 파일](docs/hangul-combination-deafult.xml)를 참고하세요. 일반적인 구조는 다음과 같습니다.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<hangul-keyboard id="2" type="jamo">
+
+    <name>Dubeolsik</name>
+    <name xml:lang="ko">두벌식</name>
+
+    <map id="0">
+        <item key="0x41" value="0x1106"/>  <!-- A → ᄆᅠ -->
+        <item key="0x42" value="0x1172"/>  <!-- B → ᅟᅲ -->
+        ...
+    </map>
+
+    <combination id="0">
+        <item first="0x1100" second="0x1100" result="0x1101"/>  <!-- ᄀ   + ᄀ   → ᄁ  -->
+        <item first="0x1169" second="0x1161" result="0x116a"/>  <!-- ᅩ   + ᅡ   → ᅪ  -->
+        ...
+    </combination>
+    <!-- 또는 -->
+    <include file="hangul-combination-default.xml"/>
+
+</hangul-keyboard>
+```
+
+* hangul-keyboard: 자판 배열을 정의하는 루트 요소.
+    * id: 입력기에서 사용하는 ID 값.
+    * type: 자판의 유형에 따라 jamo(두벌식), jamo-yet(두벌식 옛한글), jaso(세벌식), jaso-yet(세벌식 옛한글), ro(로마자)로 설정합니다.
+* map: 각 키를 눌렀을 때 입력될 문자를 설정합니다. id 값은 0으로 고정합니다.
+    * item: QWERTY 자판 기준 아스키코드 key에 해당하는 키를 누르면, 유니코드 value에 해당하는 한글 초/중/종성을 입력합니다. key와 value 값은 16진수로 지정합니다.
+* combination: 키를 연달아 누를 때 입력될 조합자를 item으로 나열합니다. id 값은 0으로 고정합니다.
+    * item: first 문자가 입력된 상태에서 second 키를 누르면 result 문자로 바뀝니다. first, second, result는 한글 초/중/종성에 대응되는 16진수 유니코드로 지정합니다.
+* include: file 경로의 XML 파일을 읽어 그 자리에 인라인합니다. file 값은 상대경로 또는 절대경로로 설정할 수 있습니다.
+
 # LICENSE
 * GNU Lesser General Public License v3.0 ([한글 해석](https://olis.or.kr/license/Detailselect.do?lId=1073))
   

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ libhangul에서 사용하는 한글 자판 배열은 두 경로에 XML 파일로
 * `/usr/share/libhangul/keyboards` 경로에 설치된 파일은 모든 사용자에게서 인식됩니다.
 * `$HOME/.local/share/libhangul/keyboards` 또는 `$XDG_DATA_HOME/libhangul/keyboards` 경로에 설치된 파일은 개별 사용자에게 인식됩니다.
 
-자판 배열 파일 구조는 기본으로 설치되는 [두벌식 배열 파일](docs/hangul-keyboard-2.xml)과 [자모 기본조합 파일](docs/hangul-combination-deafult.xml)를 참고하세요. 일반적인 구조는 다음과 같습니다.
+자판 배열 파일 구조는 기본으로 설치되는 [두벌식 배열 파일](docs/hangul-keyboard-2.xml)과 [자모 기본조합 파일](docs/hangul-combination-default.xml)를 참고하세요. 일반적인 구조는 다음과 같습니다.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -268,6 +268,7 @@ libhangul에서 사용하는 한글 자판 배열은 두 경로에 XML 파일로
 * hangul-keyboard: 자판 배열을 정의하는 루트 요소.
     * id: 입력기에서 사용하는 ID 값.
     * type: 자판의 유형에 따라 jamo(두벌식), jamo-yet(두벌식 옛한글), jaso(세벌식), jaso-yet(세벌식 옛한글), ro(로마자)로 설정합니다.
+* name: 설정 창에 나타나는 자판 배열의 이름. xml:lang 값에 따라 지역화된 이름을 설정할 수 있습니다.
 * map: 각 키를 눌렀을 때 입력될 문자를 설정합니다. id 값은 0으로 고정합니다.
     * item: QWERTY 자판 기준 아스키코드 key에 해당하는 키를 누르면, 유니코드 value에 해당하는 한글 초/중/종성을 입력합니다. key와 value 값은 16진수로 지정합니다.
 * combination: 키를 연달아 누를 때 입력될 조합자를 item으로 나열합니다. id 값은 0으로 고정합니다.

--- a/docs/hangul-combination-default.xml
+++ b/docs/hangul-combination-default.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<combination id="0">
+    <item first="0x1100" second="0x1100" result="0x1101"/>  <!-- ᄀ   + ᄀ   → ᄁ  -->
+    <item first="0x1100" second="0x1109" result="0x11aa"/>  <!-- ᄀ   + ᄉ   → ᆪ  -->
+    <item first="0x1102" second="0x110c" result="0x11ac"/>  <!-- ᄂ   + ᄌ   → ᆬ  -->
+    <item first="0x1102" second="0x1112" result="0x11ad"/>  <!-- ᄂ   + ᄒ   → ᆭ  -->
+    <item first="0x1103" second="0x1103" result="0x1104"/>  <!-- ᄃ   + ᄃ   → ᄄ  -->
+    <item first="0x1105" second="0x1100" result="0x11b0"/>  <!-- ᄅ   + ᄀ   → ᆰ  -->
+    <item first="0x1105" second="0x1106" result="0x11b1"/>  <!-- ᄅ   + ᄆ   → ᆱ  -->
+    <item first="0x1105" second="0x1107" result="0x11b2"/>  <!-- ᄅ   + ᄇ   → ᆲ  -->
+    <item first="0x1105" second="0x1109" result="0x11b3"/>  <!-- ᄅ   + ᄉ   → ᆳ  -->
+    <item first="0x1105" second="0x1110" result="0x11b4"/>  <!-- ᄅ   + ᄐ   → ᆴ  -->
+    <item first="0x1105" second="0x1111" result="0x11b5"/>  <!-- ᄅ   + ᄑ   → ᆵ  -->
+    <item first="0x1105" second="0x1112" result="0x11b6"/>  <!-- ᄅ   + ᄒ   → ᆶ  -->
+    <item first="0x1107" second="0x1107" result="0x1108"/>  <!-- ᄇ   + ᄇ   → ᄈ  -->
+    <item first="0x1107" second="0x1109" result="0x11b9"/>  <!-- ᄇ   + ᄉ   → ᆹ  -->
+    <item first="0x1109" second="0x1109" result="0x110a"/>  <!-- ᄉ   + ᄉ   → ᄊ  -->
+    <item first="0x110c" second="0x110c" result="0x110d"/>  <!-- ᄌ   + ᄌ   → ᄍ  -->
+    <item first="0x1169" second="0x1161" result="0x116a"/>  <!-- ᅩ   + ᅡ   → ᅪ  -->
+    <item first="0x1169" second="0x1162" result="0x116b"/>  <!-- ᅩ   + ᅢ   → ᅫ  -->
+    <item first="0x1169" second="0x1175" result="0x116c"/>  <!-- ᅩ   + ᅵ   → ᅬ  -->
+    <item first="0x116e" second="0x1165" result="0x116f"/>  <!-- ᅮ   + ᅥ   → ᅯ  -->
+    <item first="0x116e" second="0x1166" result="0x1170"/>  <!-- ᅮ   + ᅦ   → ᅰ  -->
+    <item first="0x116e" second="0x1175" result="0x1171"/>  <!-- ᅮ   + ᅵ   → ᅱ  -->
+    <item first="0x1173" second="0x1175" result="0x1174"/>  <!-- ᅳ   + ᅵ   → ᅴ  -->
+    <item first="0x11a8" second="0x11a8" result="0x11a9"/>  <!-- ᆨ   + ᆨ   → ᆩ  -->
+    <item first="0x11a8" second="0x11ba" result="0x11aa"/>  <!-- ᆨ   + ᆺ   → ᆪ  -->
+    <item first="0x11ab" second="0x11bd" result="0x11ac"/>  <!-- ᆫ   + ᆽ   → ᆬ  -->
+    <item first="0x11ab" second="0x11c2" result="0x11ad"/>  <!-- ᆫ   + ᇂ   → ᆭ  -->
+    <item first="0x11af" second="0x11a8" result="0x11b0"/>  <!-- ᆯ   + ᆨ   → ᆰ  -->
+    <item first="0x11af" second="0x11b7" result="0x11b1"/>  <!-- ᆯ   + ᆷ   → ᆱ  -->
+    <item first="0x11af" second="0x11b8" result="0x11b2"/>  <!-- ᆯ   + ᆸ   → ᆲ  -->
+    <item first="0x11af" second="0x11ba" result="0x11b3"/>  <!-- ᆯ   + ᆺ   → ᆳ  -->
+    <item first="0x11af" second="0x11c0" result="0x11b4"/>  <!-- ᆯ   + ᇀ   → ᆴ  -->
+    <item first="0x11af" second="0x11c1" result="0x11b5"/>  <!-- ᆯ   + ᇁ   → ᆵ  -->
+    <item first="0x11af" second="0x11c2" result="0x11b6"/>  <!-- ᆯ   + ᇂ   → ᆶ  -->
+    <item first="0x11b8" second="0x11ba" result="0x11b9"/>  <!-- ᆸ   + ᆺ   → ᆹ  -->
+    <item first="0x11ba" second="0x11ba" result="0x11bb"/>  <!-- ᆺ   + ᆺ   → ᆻ  -->
+</combination>

--- a/docs/hangul-keyboard-2.xml
+++ b/docs/hangul-keyboard-2.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hangul-keyboard id="2" type="jamo">
+
+    <name>Dubeolsik</name>
+    <name xml:lang="ko">두벌식</name>
+
+    <map id="0">
+        <item key="0x41" value="0x1106"/>  <!-- A → ᄆᅠ -->
+        <item key="0x42" value="0x1172"/>  <!-- B → ᅟᅲ -->
+        <item key="0x43" value="0x110e"/>  <!-- C → ᄎᅠ -->
+        <item key="0x44" value="0x110b"/>  <!-- D → ᄋᅠ -->
+        <item key="0x45" value="0x1104"/>  <!-- E → ᄄᅠ -->
+        <item key="0x46" value="0x1105"/>  <!-- F → ᄅᅠ -->
+        <item key="0x47" value="0x1112"/>  <!-- G → ᄒᅠ -->
+        <item key="0x48" value="0x1169"/>  <!-- H → ᅟᅩ -->
+        <item key="0x49" value="0x1163"/>  <!-- I → ᅟᅣ -->
+        <item key="0x4a" value="0x1165"/>  <!-- J → ᅟᅥ -->
+        <item key="0x4b" value="0x1161"/>  <!-- K → ᅟᅡ -->
+        <item key="0x4c" value="0x1175"/>  <!-- L → ᅟᅵ -->
+        <item key="0x4d" value="0x1173"/>  <!-- M → ᅟᅳ -->
+        <item key="0x4e" value="0x116e"/>  <!-- N → ᅟᅮ -->
+        <item key="0x4f" value="0x1164"/>  <!-- O → ᅟᅤ -->
+        <item key="0x50" value="0x1168"/>  <!-- P → ᅟᅨ -->
+        <item key="0x51" value="0x1108"/>  <!-- Q → ᄈᅠ -->
+        <item key="0x52" value="0x1101"/>  <!-- R → ᄁᅠ -->
+        <item key="0x53" value="0x1102"/>  <!-- S → ᄂᅠ -->
+        <item key="0x54" value="0x110a"/>  <!-- T → ᄊᅠ -->
+        <item key="0x55" value="0x1167"/>  <!-- U → ᅟᅧ -->
+        <item key="0x56" value="0x1111"/>  <!-- V → ᄑᅠ -->
+        <item key="0x57" value="0x110d"/>  <!-- W → ᄍᅠ -->
+        <item key="0x58" value="0x1110"/>  <!-- X → ᄐᅠ -->
+        <item key="0x59" value="0x116d"/>  <!-- Y → ᅟᅭ -->
+        <item key="0x5a" value="0x110f"/>  <!-- Z → ᄏᅠ -->
+        <item key="0x61" value="0x1106"/>  <!-- a → ᄆᅠ -->
+        <item key="0x62" value="0x1172"/>  <!-- b → ᅟᅲ -->
+        <item key="0x63" value="0x110e"/>  <!-- c → ᄎᅠ -->
+        <item key="0x64" value="0x110b"/>  <!-- d → ᄋᅠ -->
+        <item key="0x65" value="0x1103"/>  <!-- e → ᄃᅠ -->
+        <item key="0x66" value="0x1105"/>  <!-- f → ᄅᅠ -->
+        <item key="0x67" value="0x1112"/>  <!-- g → ᄒᅠ -->
+        <item key="0x68" value="0x1169"/>  <!-- h → ᅟᅩ -->
+        <item key="0x69" value="0x1163"/>  <!-- i → ᅟᅣ -->
+        <item key="0x6a" value="0x1165"/>  <!-- j → ᅟᅥ -->
+        <item key="0x6b" value="0x1161"/>  <!-- k → ᅟᅡ -->
+        <item key="0x6c" value="0x1175"/>  <!-- l → ᅟᅵ -->
+        <item key="0x6d" value="0x1173"/>  <!-- m → ᅟᅳ -->
+        <item key="0x6e" value="0x116e"/>  <!-- n → ᅟᅮ -->
+        <item key="0x6f" value="0x1162"/>  <!-- o → ᅟᅢ -->
+        <item key="0x70" value="0x1166"/>  <!-- p → ᅟᅦ -->
+        <item key="0x71" value="0x1107"/>  <!-- q → ᄇᅠ -->
+        <item key="0x72" value="0x1100"/>  <!-- r → ᄀᅠ -->
+        <item key="0x73" value="0x1102"/>  <!-- s → ᄂᅠ -->
+        <item key="0x74" value="0x1109"/>  <!-- t → ᄉᅠ -->
+        <item key="0x75" value="0x1167"/>  <!-- u → ᅟᅧ -->
+        <item key="0x76" value="0x1111"/>  <!-- v → ᄑᅠ -->
+        <item key="0x77" value="0x110c"/>  <!-- w → ᄌᅠ -->
+        <item key="0x78" value="0x1110"/>  <!-- x → ᄐᅠ -->
+        <item key="0x79" value="0x116d"/>  <!-- y → ᅟᅭ -->
+        <item key="0x7a" value="0x110f"/>  <!-- z → ᄏᅠ -->
+    </map>
+
+    <include file="hangul-combination-default.xml"/>
+
+</hangul-keyboard>

--- a/modules/engines/nimf-libhangul/nimf-libhangul.c
+++ b/modules/engines/nimf-libhangul/nimf-libhangul.c
@@ -64,23 +64,6 @@ struct _NimfLibhangulClass
   NimfEngineClass parent_class;
 };
 
-typedef struct {
-  const gchar *id;
-  const gchar *name;
-} Keyboard;
-
-static const Keyboard keyboards[] = {
-  {"2",   N_("Dubeolsik")},
-  {"2y",  N_("Dubeolsik Yetgeul")},
-  {"32",  N_("Sebeolsik Dubeol Layout")},
-  {"39",  N_("Sebeolsik 390")},
-  {"3f",  N_("Sebeolsik Final")},
-  {"3s",  N_("Sebeolsik Noshift")},
-  {"3y",  N_("Sebeolsik Yetgeul")},
-  {"ro",  N_("Romaja")},
-  {"ahn", N_("Ahnmatae")}
-};
-
 static HanjaTable *nimf_libhangul_hanja_table  = NULL;
 static HanjaTable *nimf_libhangul_symbol_table = NULL;
 static gint        nimf_libhangul_hanja_table_ref_count = 0;
@@ -718,6 +701,8 @@ nimf_libhangul_init (NimfLibhangul *hangul)
 
   gchar **hanja_keys;
 
+  hangul_init ();
+
   hangul->settings = g_settings_new ("org.nimf.engines.nimf-libhangul");
   hangul->method = g_settings_get_string (hangul->settings, "get-method-infos");
   hangul->is_double_consonant_rule =
@@ -783,6 +768,8 @@ nimf_libhangul_finalize (GObject *object)
   g_free (hangul->method);
   nimf_key_freev (hangul->hanja_keys);
   g_object_unref (hangul->settings);
+
+  hangul_fini();
 
   G_OBJECT_CLASS (nimf_libhangul_parent_class)->finalize (object);
 }
@@ -863,8 +850,10 @@ nimf_libhangul_get_method_infos ()
 {
   g_debug (G_STRLOC ": %s", G_STRFUNC);
 
+  hangul_init ();
+
   NimfMethodInfo **infos;
-  gint             n_methods = G_N_ELEMENTS (keyboards);
+  gint             n_methods = hangul_keyboard_list_get_count ();
   gint             i;
 
   infos = g_malloc (sizeof (NimfMethodInfo *) * n_methods + 1);
@@ -872,8 +861,8 @@ nimf_libhangul_get_method_infos ()
   for (i = 0; i < n_methods; i++)
   {
     infos[i] = nimf_method_info_new ();
-    infos[i]->method_id = g_strdup (keyboards[i].id);
-    infos[i]->label     = g_strdup (gettext (keyboards[i].name));
+    infos[i]->method_id = g_strdup (hangul_keyboard_list_get_keyboard_id (i));
+    infos[i]->label     = g_strdup (hangul_keyboard_list_get_keyboard_name (i));
     infos[i]->group     = NULL;
   }
 


### PR DESCRIPTION
Hardcoded keyboard list in nimf-libhangul module is removed. Instead, the available methods list is provided by libhangul, which are parsed from external xml files.

It enables adding user-defined keyboard layouts. Please refer to ["한글 키보드 추가 방법" section of libhangul documentation](https://libhangul.github.io/libhangul-doc/git/group__hangulkeyboards.html#addinghangulkeyboards).