### PR TITLE
feat: add Ubuntu 24.10 (questing) support to install script

### DIFF
--- a/install
+++ b/install
@@ -173,6 +173,13 @@ install_debian() {
             if [[ "$pkg_arch" == "arm64" ]]; then
                 pkg_suffix="ubuntu.2404.arm64"
             fi
+            # Ubuntu 24.10 (questing) support - use 24.04 packages for compatibility
+            if [[ "$OS_CODENAME" == "questing" ]]; then
+                pkg_suffix="ubuntu.2404"
+                if [[ "$pkg_arch" == "arm64" ]]; then
+                    pkg_suffix="ubuntu.2404.arm64"
+                fi
+            fi
             ;;
         *)
             pkg_suffix="ubuntu.2404"


### PR DESCRIPTION
## Summary
- Add explicit support for Ubuntu 24.10 "questing" codename to the install script
- "questing" is used in Termux proot-distro ubuntu environments
- Uses Ubuntu 24.04 packages for compatibility with 24.10

## Test plan
- [x] Code review confirms questing codename is now handled
- [ ] Test in actual Termux proot-distro ubuntu environment (questing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)